### PR TITLE
Revert "Bump lodash from 4.17.19 to 4.17.21 in /api"

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1728,9 +1728,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lowercase-keys": {
       "version": "1.0.1",


### PR DESCRIPTION
Reverts DevMo-13/full-stack-app-with-react-and-rest-api#5